### PR TITLE
Made closing of SubPaths explicit.

### DIFF
--- a/examples/demo-glutin.rs
+++ b/examples/demo-glutin.rs
@@ -78,6 +78,7 @@ fn main() {
                 path.sub_path(origin, |sp| {
                     sp.line_to((origin.0 + 300.0, origin.1 - 50.0));
                     sp.quad_bezier_to((origin.0 + 500.0, origin.1 + 100.0), (300.0, 100.0));
+                    sp.close();
                 });
                 path.stroke(StrokeStyle {
                     coloring_style: ColoringStyle::Color(Color::new(1.0, 1.0, 0.0, 1.0)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,6 @@ impl<'a, 'b> Path<'a, 'b> {
         let ctx = self.ctx();
         unsafe { ffi::nvgMoveTo(ctx, x, y); }
         handler(SubPath::new(self));
-        unsafe { ffi::nvgClosePath(ctx); }
     }
 }
 
@@ -351,6 +350,10 @@ impl<'a, 'b, 'c> SubPath<'a, 'b, 'c> {
 
     pub fn winding(&self, direction: Direction) {
         unsafe { ffi::nvgPathWinding(self.ctx(), direction.into_raw().bits()); }
+    }
+
+    pub fn close(&self) {
+        unsafe { ffi::nvgClosePath(self.ctx()); }
     }
 }
 


### PR DESCRIPTION
This is my attempt to fix issue #5. I did exactly what I suggested in the issue: `SubPath`s have to be closed explicitly by calling `close`.